### PR TITLE
add strip_prefix for idris_library

### DIFF
--- a/idris/idris_loader.bzl
+++ b/idris/idris_loader.bzl
@@ -6,7 +6,7 @@ def loadIdris(localIdrisInstallation=None):
   loadScala()
   nixpkgs_git_repository(
       name = "nixpkgs",
-      revision = "da53c1248ba3c56d0ee67d8ab1d0849f9453bbb5", # Any tag or commit hash
+      revision = "3a393eecafb3fcd9db5ff94783ddab0c55d15860", # Any tag or commit hash
       sha256 = "" # optional sha to verify package integrity!
   )
   nixpkgs_package(

--- a/idris/idris_repos.bzl
+++ b/idris/idris_repos.bzl
@@ -11,15 +11,15 @@ def loadIdrisPackagerRepositories():
   )
   git_repository(
     name = "idris_packager",
-    commit = "284488c94370aa45f69703d0b300c4f2244b279f",
-    remote = "https://github.com/BryghtWords/idris_packager.git"
+    commit = "b8359edbf551173024b7e57f23da0ad88efd4f69",
+    remote = "https://github.com/shmish111/idris_packager.git"
   )
 
 def loadNixRepositories():
   http_archive(
     name = "io_tweag_rules_nixpkgs",
-    strip_prefix = "rules_nixpkgs-4575647f3795fee2a8b732f97076a363907f7248",
-    urls = ["https://github.com/tweag/rules_nixpkgs/archive/4575647f3795fee2a8b732f97076a363907f7248.tar.gz"],
+    strip_prefix = "rules_nixpkgs-674766086cda88976394fbd608620740857e2535",
+    urls = ["https://github.com/tweag/rules_nixpkgs/archive/674766086cda88976394fbd608620740857e2535.tar.gz"],
   )
 
 def loadIdrisRepositories():


### PR DESCRIPTION
Tested with a library that has code in `src` and one that does not. I'm not sure how robust it is yet, will need to use it with other packages.